### PR TITLE
import permissions decorator from original location

### DIFF
--- a/tethysapp/dam_inventory/controllers.py
+++ b/tethysapp/dam_inventory/controllers.py
@@ -1,9 +1,9 @@
 from django.shortcuts import render, reverse, redirect
 from django.contrib import messages
-from django.contrib.auth.decorators import login_required
+from django.contrib.auth.decorators import login_required, permission_required
 from django.utils.html import format_html
 from tethys_sdk.gizmos import MapView, Button, TextInput, DatePicker, SelectInput, DataTableView, MVDraw, MVView, MVLayer
-from tethys_sdk.permissions import permission_required, has_permission
+from tethys_sdk.permissions import has_permission
 
 from .model import add_new_dam, get_all_dams, Dam, assign_hydrograph_to_dam, get_hydrograph
 from .app import DamInventory as app


### PR DESCRIPTION
Apparently decorators now need to be imported from their original location, else they will not work.

An upcoming PR to tethys itself will also change this in the advanced tutorial